### PR TITLE
修复网易云音乐歌单歌曲获取不完整的问题

### DIFF
--- a/src/api/provider/netease.js
+++ b/src/api/provider/netease.js
@@ -86,7 +86,7 @@ function getNEScore(song) {
 }
 
 function isPlayable(song) {
-  return (song.fee !== 4) && (song.fee !== 1);
+  return getNEScore(song) < 100;
 }
 
 function convert(allowAll) {

--- a/src/api/provider/netease.js
+++ b/src/api/provider/netease.js
@@ -86,7 +86,7 @@ function getNEScore(song) {
 }
 
 function isPlayable(song) {
-  return getNEScore(song) < 100;
+  return (song.fee !== 4) && (song.fee !== 1);
 }
 
 function convert(allowAll) {
@@ -116,21 +116,29 @@ function getPlaylist(playlistId) {
     csrf_token: '',
   };
 
-  const url = 'http://music.163.com/weapi/v3/playlist/detail';
+  const playlist_url = 'http://music.163.com/weapi/v3/playlist/detail';
+  const tracks_url = 'https://music.163.com/weapi/v3/song/detail';
 
-  return requestAPI(url, data).then(resData => {
+  return requestAPI(playlist_url, data).then(resData => {
     const info = {
       id: `neplaylist_${listId}`,
       cover_img_url: getSmallImageUrl(resData.playlist.coverImgUrl),
       title: resData.playlist.name,
       source_url: `http://music.163.com/#/playlist?id=${listId}`,
     };
-    const tracks = resData.playlist.tracks.map(convert(true));
 
-    return {
-      info,
-      tracks,
-    };
+    // request all tracks to fetch song info
+    // Code reference from listen1_chrome_extension
+    const track_ids = resData.playlist.trackIds.map(i=>i.id);
+    const data = {
+      c: '[' + track_ids.map(id => ('{"id":' + id + '}')).join(',') + ']',
+      ids: '[' + track_ids.join(',') + ']'
+    }
+
+    return requestAPI(tracks_url, data).then(response => {
+      const tracks=response.songs.map(convert(true));
+      return {info, tracks,};
+    });
   });
 }
 


### PR DESCRIPTION
做了一点小修改：
- 通过添加请求api:song/detail的部分修复网易云音乐歌单获取不完整的问题(参考自listen1 chrome插件版)
- ~~(网易云音乐)版权歌曲试听，而不是直接跳过 (至少可以先听听嘛 😏)~~